### PR TITLE
Refactor reap(), move statistics logic to resource get functions, ID/Region now functions

### DIFF
--- a/aws/autoscaling.go
+++ b/aws/autoscaling.go
@@ -55,7 +55,7 @@ func (s *autoScalingGroupScalingSchedule) setSchedule(tag string) {
 
 // SaveSchedule is a method of the Scaler interface
 func (a *AutoScalingGroup) SaveSchedule() {
-	tagAutoScalingGroup(a.Region, a.ID, scalerTag, a.Scheduling.scheduleTag())
+	tagAutoScalingGroup(a.Region(), a.ID(), scalerTag, a.Scheduling.scheduleTag())
 }
 
 // SetScaleDownString is a method of the Scaler interface
@@ -93,8 +93,8 @@ type AutoScalingGroup struct {
 func NewAutoScalingGroup(region string, asg *autoscaling.Group) *AutoScalingGroup {
 	a := AutoScalingGroup{
 		Resource: Resource{
-			Region: reapable.Region(region),
-			ID:     reapable.ID(*asg.AutoScalingGroupName),
+			region: reapable.Region(region),
+			id:     reapable.ID(*asg.AutoScalingGroupName),
 			Name:   *asg.AutoScalingGroupName,
 			Tags:   make(map[string]string),
 		},
@@ -182,43 +182,43 @@ type autoScalingGroupEventData struct {
 }
 
 func (a *AutoScalingGroup) getTemplateData() (interface{}, error) {
-	ignore1, err := makeIgnoreLink(a.Region, a.ID, config.HTTP.TokenSecret, config.HTTP.APIURL, time.Duration(1*24*time.Hour))
+	ignore1, err := makeIgnoreLink(a.Region(), a.ID(), config.HTTP.TokenSecret, config.HTTP.APIURL, time.Duration(1*24*time.Hour))
 	if err != nil {
 		return nil, err
 	}
-	ignore3, err := makeIgnoreLink(a.Region, a.ID, config.HTTP.TokenSecret, config.HTTP.APIURL, time.Duration(3*24*time.Hour))
+	ignore3, err := makeIgnoreLink(a.Region(), a.ID(), config.HTTP.TokenSecret, config.HTTP.APIURL, time.Duration(3*24*time.Hour))
 	if err != nil {
 		return nil, err
 	}
-	ignore7, err := makeIgnoreLink(a.Region, a.ID, config.HTTP.TokenSecret, config.HTTP.APIURL, time.Duration(7*24*time.Hour))
+	ignore7, err := makeIgnoreLink(a.Region(), a.ID(), config.HTTP.TokenSecret, config.HTTP.APIURL, time.Duration(7*24*time.Hour))
 	if err != nil {
 		return nil, err
 	}
-	terminate, err := makeTerminateLink(a.Region, a.ID, config.HTTP.TokenSecret, config.HTTP.APIURL)
+	terminate, err := makeTerminateLink(a.Region(), a.ID(), config.HTTP.TokenSecret, config.HTTP.APIURL)
 	if err != nil {
 		return nil, err
 	}
-	stop, err := makeStopLink(a.Region, a.ID, config.HTTP.TokenSecret, config.HTTP.APIURL)
+	stop, err := makeStopLink(a.Region(), a.ID(), config.HTTP.TokenSecret, config.HTTP.APIURL)
 	if err != nil {
 		return nil, err
 	}
-	forcestop, err := makeForceStopLink(a.Region, a.ID, config.HTTP.TokenSecret, config.HTTP.APIURL)
+	forcestop, err := makeForceStopLink(a.Region(), a.ID(), config.HTTP.TokenSecret, config.HTTP.APIURL)
 	if err != nil {
 		return nil, err
 	}
-	whitelist, err := makeWhitelistLink(a.Region, a.ID, config.HTTP.TokenSecret, config.HTTP.APIURL)
+	whitelist, err := makeWhitelistLink(a.Region(), a.ID(), config.HTTP.TokenSecret, config.HTTP.APIURL)
 	if err != nil {
 		return nil, err
 	}
-	schedulePacific, err := makeScheduleLink(a.Region, a.ID, config.HTTP.TokenSecret, config.HTTP.APIURL, scaleDownPacificBusinessHours, scaleUpPacificBusinessHours)
+	schedulePacific, err := makeScheduleLink(a.Region(), a.ID(), config.HTTP.TokenSecret, config.HTTP.APIURL, scaleDownPacificBusinessHours, scaleUpPacificBusinessHours)
 	if err != nil {
 		return nil, err
 	}
-	scheduleEastern, err := makeScheduleLink(a.Region, a.ID, config.HTTP.TokenSecret, config.HTTP.APIURL, scaleDownEasternBusinessHours, scaleUpEasternBusinessHours)
+	scheduleEastern, err := makeScheduleLink(a.Region(), a.ID(), config.HTTP.TokenSecret, config.HTTP.APIURL, scaleDownEasternBusinessHours, scaleUpEasternBusinessHours)
 	if err != nil {
 		return nil, err
 	}
-	scheduleCEST, err := makeScheduleLink(a.Region, a.ID, config.HTTP.TokenSecret, config.HTTP.APIURL, scaleDownCESTBusinessHours, scaleUpCESTBusinessHours)
+	scheduleCEST, err := makeScheduleLink(a.Region(), a.ID(), config.HTTP.TokenSecret, config.HTTP.APIURL, scaleDownCESTBusinessHours, scaleUpCESTBusinessHours)
 	if err != nil {
 		return nil, err
 	}
@@ -344,13 +344,13 @@ func (a *AutoScalingGroup) sizeGreaterThan(size int64) bool {
 
 // Save is part of reapable.Saveable, which embedded in reapable.Reapable
 func (a *AutoScalingGroup) Save(s *state.State) (bool, error) {
-	return tagAutoScalingGroup(a.Region, a.ID, reaperTag, a.reaperState.String())
+	return tagAutoScalingGroup(a.Region(), a.ID(), reaperTag, a.reaperState.String())
 }
 
 // Unsave is part of reapable.Saveable, which embedded in reapable.Reapable
 func (a *AutoScalingGroup) Unsave() (bool, error) {
 	log.Info("Unsaving %s", a.ReapableDescriptionTiny())
-	return untagAutoScalingGroup(a.Region, a.ID, reaperTag)
+	return untagAutoScalingGroup(a.Region(), a.ID(), reaperTag)
 }
 
 func untagAutoScalingGroup(region reapable.Region, id reapable.ID, key string) (bool, error) {
@@ -375,7 +375,7 @@ func untagAutoScalingGroup(region reapable.Region, id reapable.ID, key string) (
 
 func tagAutoScalingGroup(region reapable.Region, id reapable.ID, key, value string) (bool, error) {
 	log.Info("Tagging AutoScalingGroup %s in %s with %s:%s", region.String(), id.String(), key, value)
-	api := autoscaling.New(session.New(&aws.Config{Region: aws.String(string(region))}))
+	api := autoscaling.New(session.New(&aws.Config{Region: aws.String(region.String())}))
 	createreq := &autoscaling.CreateOrUpdateTagsInput{
 		Tags: []*autoscaling.Tag{
 			&autoscaling.Tag{
@@ -437,7 +437,7 @@ func (a *AutoScalingGroup) Filter(filter filters.Filter) bool {
 		}
 	case "Region":
 		for _, region := range filter.Arguments {
-			if a.Region == reapable.Region(region) {
+			if a.Region() == reapable.Region(region) {
 				matched = true
 			}
 		}
@@ -445,7 +445,7 @@ func (a *AutoScalingGroup) Filter(filter filters.Filter) bool {
 		// was this resource's region one of those in the NOT list
 		regionSpecified := false
 		for _, region := range filter.Arguments {
-			if a.Region == reapable.Region(region) {
+			if a.Region() == reapable.Region(region) {
 				regionSpecified = true
 			}
 		}
@@ -501,7 +501,7 @@ func (a *AutoScalingGroup) Filter(filter filters.Filter) bool {
 // AWSConsoleURL returns the url that can be used to access the resource on the AWS Console
 func (a *AutoScalingGroup) AWSConsoleURL() *url.URL {
 	url, err := url.Parse(fmt.Sprintf("https://%s.console.aws.amazon.com/ec2/autoscaling/home?region=%s#AutoScalingGroups:id=%s;view=details",
-		a.Region.String(), a.Region.String(), url.QueryEscape(a.ID.String())))
+		a.Region().String(), a.Region().String(), url.QueryEscape(a.ID().String())))
 	if err != nil {
 		log.Error("Error generating AWSConsoleURL. ", err)
 	}
@@ -539,10 +539,9 @@ func (a *AutoScalingGroup) ScaleUp() {
 
 func (a *AutoScalingGroup) scaleToSize(size int64, minSize int64) (bool, error) {
 	log.Info("Scaling AutoScalingGroup %s to size %d.", a.ReapableDescriptionTiny(), size)
-	as := autoscaling.New(session.New(&aws.Config{Region: aws.String(string(a.Region))}))
-	idString := a.ID.String()
+	as := autoscaling.New(session.New(&aws.Config{Region: aws.String(a.Region().String())}))
 	input := &autoscaling.UpdateAutoScalingGroupInput{
-		AutoScalingGroupName: &idString,
+		AutoScalingGroupName: aws.String(a.ID().String()),
 		DesiredCapacity:      &size,
 		MinSize:              &minSize,
 	}
@@ -558,10 +557,9 @@ func (a *AutoScalingGroup) scaleToSize(size int64, minSize int64) (bool, error) 
 // Terminate is a method of reapable.Terminable, which is embedded in reapable.Reapable
 func (a *AutoScalingGroup) Terminate() (bool, error) {
 	log.Info("Terminating AutoScalingGroup %s", a.ReapableDescriptionTiny())
-	as := autoscaling.New(session.New(&aws.Config{Region: aws.String(string(a.Region))}))
-	idString := a.ID.String()
+	as := autoscaling.New(session.New(&aws.Config{Region: aws.String(a.Region().String())}))
 	input := &autoscaling.DeleteAutoScalingGroupInput{
-		AutoScalingGroupName: &idString,
+		AutoScalingGroupName: aws.String(a.ID().String()),
 	}
 	_, err := as.DeleteAutoScalingGroup(input)
 	if err != nil {
@@ -574,11 +572,11 @@ func (a *AutoScalingGroup) Terminate() (bool, error) {
 // Whitelist is a method of reapable.Whitelistable, which is embedded in reapable.Reapable
 func (a *AutoScalingGroup) Whitelist() (bool, error) {
 	log.Info("Whitelisting AutoScalingGroup %s", a.ReapableDescriptionTiny())
-	api := autoscaling.New(session.New(&aws.Config{Region: aws.String(string(a.Region))}))
+	api := autoscaling.New(session.New(&aws.Config{Region: aws.String(a.Region().String())}))
 	createreq := &autoscaling.CreateOrUpdateTagsInput{
 		Tags: []*autoscaling.Tag{
 			&autoscaling.Tag{
-				ResourceId:        aws.String(string(a.ID)),
+				ResourceId:        aws.String(a.ID().String()),
 				ResourceType:      aws.String("auto-scaling-group"),
 				PropagateAtLaunch: aws.Bool(false),
 				Key:               aws.String(config.WhitelistTag),

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -170,7 +170,7 @@ func AutoScalingGroupInstanceIDs(a *AutoScalingGroup) map[reapable.Region]map[re
 	}
 	for _, instanceID := range a.Instances {
 		// add the instance to the map
-		inASG[a.Region][instanceID] = true
+		inASG[a.Region()][instanceID] = true
 	}
 	return inASG
 }

--- a/aws/resource.go
+++ b/aws/resource.go
@@ -19,9 +19,10 @@ import (
 
 // Resource has properties shared by all AWS resources
 type Resource struct {
-	ID                 reapable.ID
+	id     reapable.ID
+	region reapable.Region
+
 	Name               string
-	Region             reapable.Region
 	Dependency         bool
 	IsInCloudformation bool
 
@@ -32,6 +33,16 @@ type Resource struct {
 
 	// filters for MatchedFilters
 	matchedFilterGroups map[string]filters.FilterGroup
+}
+
+// ID is a method of reapable
+func (a *Resource) ID() reapable.ID {
+	return a.id
+}
+
+// Region is a method of reapable
+func (a *Resource) Region() reapable.Region {
+	return a.region
 }
 
 // Tagged returns whether the Resource is tagged with that key
@@ -190,31 +201,31 @@ func (a *Resource) ReapableDescriptionShort() string {
 	if name := a.Tag("Name"); name != "" {
 		nameString = fmt.Sprintf(" \"%s\"", name)
 	}
-	return fmt.Sprintf("'%s'%s%s in %s with state: %s", a.ID, nameString, ownerString, a.Region, a.ReaperState().String())
+	return fmt.Sprintf("'%s'%s%s in %s with state: %s", a.ID(), nameString, ownerString, a.Region(), a.ReaperState().String())
 }
 
 // ReapableDescriptionTiny is a method of reapable.Reapable
 func (a *Resource) ReapableDescriptionTiny() string {
-	return fmt.Sprintf("'%s' in %s", a.ID, a.Region)
+	return fmt.Sprintf("'%s' in %s", a.ID(), a.Region())
 }
 
 // Whitelist is a method of reapable.Whitelistable, which is embedded in reapable.Reapable
 func (a *Resource) Whitelist() (bool, error) {
-	return tag(a.Region.String(), a.ID.String(), config.WhitelistTag, "true")
+	return tag(a.Region().String(), a.ID().String(), config.WhitelistTag, "true")
 }
 
 // Save is a method of reapable.Saveable, which is embedded in reapable.Reapable
 // Save tags a Resource's reaperTag
 func (a *Resource) Save(reaperState *state.State) (bool, error) {
 	log.Info("Saving %s", a.ReapableDescriptionTiny())
-	return tag(string(a.Region), string(a.ID), reaperTag, reaperState.String())
+	return tag(a.Region().String(), a.ID().String(), reaperTag, reaperState.String())
 }
 
 // Unsave is a method of reapable.Saveable, which is embedded in reapable.Reapable
 // Unsave untags a Resource's reaperTag
 func (a *Resource) Unsave() (bool, error) {
 	log.Info("Unsaving %s", a.ReapableDescriptionTiny())
-	return untag(string(a.Region), string(a.ID), reaperTag)
+	return untag(a.Region().String(), a.ID().String(), reaperTag)
 }
 
 func untag(region, id, key string) (bool, error) {

--- a/aws/snapshot.go
+++ b/aws/snapshot.go
@@ -21,8 +21,8 @@ type Snapshot struct {
 func NewSnapshot(region string, s *ec2.Snapshot) *Snapshot {
 	snap := Snapshot{
 		Resource: Resource{
-			ID:     reapable.ID(*s.SnapshotId),
-			Region: reapable.Region(region),
+			id:     reapable.ID(*s.SnapshotId),
+			region: reapable.Region(region),
 			Tags:   make(map[string]string),
 		},
 		SizeGB:        *s.VolumeSize,

--- a/reapable/reapable.go
+++ b/reapable/reapable.go
@@ -2,6 +2,7 @@ package reapable
 
 import (
 	"fmt"
+	"net/mail"
 	"sync"
 
 	"github.com/mozilla-services/reaper/filters"
@@ -53,6 +54,7 @@ type Reapable interface {
 	Whitelistable
 	Saveable
 
+	Owner() *mail.Address
 	ReapableDescription() string
 	ReapableDescriptionShort() string
 	ReapableDescriptionTiny() string

--- a/reapable/reapable.go
+++ b/reapable/reapable.go
@@ -27,6 +27,7 @@ type Saveable interface {
 	Unsave() (bool, error)
 	ReaperState() *state.State
 	IncrementState() bool
+	SetUpdated(bool)
 }
 
 //                ,____
@@ -55,6 +56,9 @@ type Reapable interface {
 	Saveable
 
 	Owner() *mail.Address
+	ID() ID
+	Region() Region
+
 	ReapableDescription() string
 	ReapableDescriptionShort() string
 	ReapableDescriptionTiny() string
@@ -114,8 +118,16 @@ func (rs *Reapables) Delete(region Region, id ID) {
 
 type ReapableContainer struct {
 	Reapable
-	Region Region
-	ID     ID
+	region Region
+	id     ID
+}
+
+func (r *ReapableContainer) Region() Region {
+	return r.region
+}
+
+func (r *ReapableContainer) ID() ID {
+	return r.id
 }
 
 func (rs *Reapables) Iter() <-chan ReapableContainer {

--- a/reaper/reaper.go
+++ b/reaper/reaper.go
@@ -230,15 +230,21 @@ func getSecurityGroups() chan *reaperaws.SecurityGroup {
 		}
 		go func() {
 			for region, regionSum := range regionSums {
-				err := reaperevents.NewStatistic("reaper.securitygroups.total", float64(regionSum), []string{fmt.Sprintf("region:%s", region), config.EventTag})
+				err := reaperevents.NewStatistic("reaper.securitygroups.total",
+					float64(regionSum),
+					[]string{fmt.Sprintf("region:%s", region), config.EventTag})
 				if err != nil {
 					log.Error(err.Error())
 				}
-				err = reaperevents.NewStatistic("reaper.securitygroups.whitelistedCount", float64(whitelistedCount[region]), []string{fmt.Sprintf("region:%s", region), config.EventTag})
+				err = reaperevents.NewStatistic("reaper.securitygroups.whitelistedCount",
+					float64(whitelistedCount[region]),
+					[]string{fmt.Sprintf("region:%s", region), config.EventTag})
 				if err != nil {
 					log.Error(err.Error())
 				}
-				err = reaperevents.NewStatistic("reaper.securitygroups.filtered", float64(filteredCount[region]), []string{fmt.Sprintf("region:%s", region), config.EventTag})
+				err = reaperevents.NewStatistic("reaper.securitygroups.filtered",
+					float64(filteredCount[region]),
+					[]string{fmt.Sprintf("region:%s", region), config.EventTag})
 				if err != nil {
 					log.Error(err.Error())
 				}
@@ -289,15 +295,21 @@ func getVolumes() chan *reaperaws.Volume {
 		go func() {
 			for region, regionMap := range volumeSizeSums {
 				for volumeType, volumeSizeSum := range regionMap {
-					err := reaperevents.NewStatistic("reaper.volumes.total", float64(volumeSizeSum), []string{fmt.Sprintf("region:%s,volumesize:%d", region, volumeType)})
+					err := reaperevents.NewStatistic("reaper.volumes.total",
+						float64(volumeSizeSum),
+						[]string{fmt.Sprintf("region:%s,volumesize:%d", region, volumeType)})
 					if err != nil {
 						log.Error(err.Error())
 					}
-					err = reaperevents.NewStatistic("reaper.volumes.filtered", float64(filteredCount[region]), []string{fmt.Sprintf("region:%s,volumesize:%d", region, volumeType)})
+					err = reaperevents.NewStatistic("reaper.volumes.filtered",
+						float64(filteredCount[region]),
+						[]string{fmt.Sprintf("region:%s,volumesize:%d", region, volumeType)})
 					if err != nil {
 						log.Error(err.Error())
 					}
-					err = reaperevents.NewStatistic("reaper.volumes.whitelistedCount", float64(whitelistedCount[region]), []string{fmt.Sprintf("region:%s,volumesize:%d", region, volumeType)})
+					err = reaperevents.NewStatistic("reaper.volumes.whitelistedCount",
+						float64(whitelistedCount[region]),
+						[]string{fmt.Sprintf("region:%s,volumesize:%d", region, volumeType)})
 					if err != nil {
 						log.Error(err.Error())
 					}
@@ -361,7 +373,9 @@ func getInstances() chan *reaperaws.Instance {
 							if err != nil {
 								log.Error(err.Error())
 							}
-							err = reaperevents.NewStatistic("reaper.instances.totalcost", float64(instanceTypeSum)*priceFloat, []string{fmt.Sprintf("region:%s,instancetype:%s", region, instanceType), config.EventTag})
+							err = reaperevents.NewStatistic("reaper.instances.totalcost",
+								float64(instanceTypeSum)*priceFloat,
+								[]string{fmt.Sprintf("region:%s,instancetype:%s", region, instanceType), config.EventTag})
 							if err != nil {
 								log.Error(err.Error())
 							}
@@ -370,15 +384,21 @@ func getInstances() chan *reaperaws.Instance {
 							log.Error(fmt.Sprintf("No price for %s", instanceType))
 						}
 					}
-					err := reaperevents.NewStatistic("reaper.instances.total", float64(instanceTypeSum), []string{fmt.Sprintf("region:%s,instancetype:%s", region, instanceType), config.EventTag})
+					err := reaperevents.NewStatistic("reaper.instances.total",
+						float64(instanceTypeSum),
+						[]string{fmt.Sprintf("region:%s,instancetype:%s", region, instanceType), config.EventTag})
 					if err != nil {
 						log.Error(err.Error())
 					}
-					err = reaperevents.NewStatistic("reaper.instances.filtered", float64(filteredCount[region]), []string{fmt.Sprintf("region:%s,instancetype:%s", region, instanceType), config.EventTag})
+					err = reaperevents.NewStatistic("reaper.instances.filtered",
+						float64(filteredCount[region]),
+						[]string{fmt.Sprintf("region:%s,instancetype:%s", region, instanceType), config.EventTag})
 					if err != nil {
 						log.Error(err.Error())
 					}
-					err = reaperevents.NewStatistic("reaper.instances.whitelistedCount", float64(whitelistedCount[region]), []string{fmt.Sprintf("region:%s,instancetype:%s", region, instanceType), config.EventTag})
+					err = reaperevents.NewStatistic("reaper.instances.whitelistedCount",
+						float64(whitelistedCount[region]),
+						[]string{fmt.Sprintf("region:%s,instancetype:%s", region, instanceType), config.EventTag})
 					if err != nil {
 						log.Error(err.Error())
 					}
@@ -419,15 +439,21 @@ func getCloudformations() chan *reaperaws.Cloudformation {
 		}
 		go func() {
 			for region, regionSum := range regionSums {
-				err := reaperevents.NewStatistic("reaper.cloudformations.total", float64(regionSum), []string{fmt.Sprintf("region:%s", region), config.EventTag})
+				err := reaperevents.NewStatistic("reaper.cloudformations.total",
+					float64(regionSum),
+					[]string{fmt.Sprintf("region:%s", region), config.EventTag})
 				if err != nil {
 					log.Error(err.Error())
 				}
-				err = reaperevents.NewStatistic("reaper.cloudformations.filtered", float64(filteredCount[region]), []string{fmt.Sprintf("region:%s", region), config.EventTag})
+				err = reaperevents.NewStatistic("reaper.cloudformations.filtered",
+					float64(filteredCount[region]),
+					[]string{fmt.Sprintf("region:%s", region), config.EventTag})
 				if err != nil {
 					log.Error(err.Error())
 				}
-				err = reaperevents.NewStatistic("reaper.cloudformations.whitelistedCount", float64(whitelistedCount[region]), []string{fmt.Sprintf("region:%s", region), config.EventTag})
+				err = reaperevents.NewStatistic("reaper.cloudformations.whitelistedCount",
+					float64(whitelistedCount[region]),
+					[]string{fmt.Sprintf("region:%s", region), config.EventTag})
 				if err != nil {
 					log.Error(err.Error())
 				}
@@ -478,22 +504,30 @@ func getAutoScalingGroups() chan *reaperaws.AutoScalingGroup {
 		go func() {
 			for region, regionMap := range asgSizeSums {
 				for asgSize, asgSizeSum := range regionMap {
-					err := reaperevents.NewStatistic("reaper.asgs.asgsizes", float64(asgSizeSum), []string{fmt.Sprintf("region:%s,asgsize:%d", region, asgSize), config.EventTag})
+					err := reaperevents.NewStatistic("reaper.asgs.asgsizes",
+						float64(asgSizeSum),
+						[]string{fmt.Sprintf("region:%s,asgsize:%d", region, asgSize), config.EventTag})
 					if err != nil {
 						log.Error(err.Error())
 					}
 				}
 			}
 			for region, regionSum := range regionSums {
-				err := reaperevents.NewStatistic("reaper.asgs.total", float64(regionSum), []string{fmt.Sprintf("region:%s", region), config.EventTag})
+				err := reaperevents.NewStatistic("reaper.asgs.total",
+					float64(regionSum),
+					[]string{fmt.Sprintf("region:%s", region), config.EventTag})
 				if err != nil {
 					log.Error(err.Error())
 				}
-				err = reaperevents.NewStatistic("reaper.asgs.filtered", float64(filteredCount[region]), []string{fmt.Sprintf("region:%s", region), config.EventTag})
+				err = reaperevents.NewStatistic("reaper.asgs.filtered",
+					float64(filteredCount[region]),
+					[]string{fmt.Sprintf("region:%s", region), config.EventTag})
 				if err != nil {
 					log.Error(err.Error())
 				}
-				err = reaperevents.NewStatistic("reaper.asgs.whitelistedCount", float64(whitelistedCount[region]), []string{fmt.Sprintf("region:%s", region), config.EventTag})
+				err = reaperevents.NewStatistic("reaper.asgs.whitelistedCount",
+					float64(whitelistedCount[region]),
+					[]string{fmt.Sprintf("region:%s", region), config.EventTag})
 				if err != nil {
 					log.Error(err.Error())
 				}
@@ -680,21 +714,21 @@ func matchesFilters(filterable filters.Filterable) bool {
 
 	matched := false
 
-	// if there are no filters groups defined, default to a match
+	// if there are no filters groups defined, match
 	if len(groups) == 0 {
-		matched = true
+		return true
 	}
 
-	// if there are no filters, default to a match
-	noFilters := true
+	shouldFilter := false
 	for _, group := range groups {
-		if len(group) != 0 {
-			// set to false if any are non-zero length
-			noFilters = false
+		if len(group) > 0 {
+			// there is a filter
+			shouldFilter = true
 		}
 	}
-	if noFilters {
-		matched = true
+	// no filters, default to a match
+	if !shouldFilter {
+		return true
 	}
 
 	for name, group := range groups {


### PR DESCRIPTION
simplify reap logic, move statistics tracking to get resource functions, add ID and Region to reapable interface and replace everywhere
separate out owner mapping from main logic, filter resources individually with matchesFilters, move logic for whitelistedCounts so that they are not per owner
