### PR TITLE
Improve DryRun behavior

### DIFF
--- a/aws/resource.go
+++ b/aws/resource.go
@@ -91,12 +91,18 @@ func (a *Resource) Owner() *mail.Address {
 	}
 
 	// default owner is specified
-	if addr, err := mail.ParseAddress(
-		fmt.Sprintf("%s@%s", config.DefaultOwner, config.DefaultEmailHost)); config.DefaultOwner != "" && config.DefaultEmailHost != "" && err == nil {
-		return addr
+	var addr *mail.Address
+	var err error
+	if config.DefaultOwner != "" {
+		addr, err = mail.ParseAddress(config.DefaultOwner)
+	} else {
+		log.Warning("DefaultOwner is not set.")
 	}
-	log.Warning("No default owner or email host.")
-	return nil
+	if err != nil || addr == nil {
+		log.Error("Resource Owner() failed: ", err.Error())
+		return nil
+	}
+	return addr
 }
 
 // IncrementState updates the ReaperState of a Resource

--- a/aws/resource.go
+++ b/aws/resource.go
@@ -97,7 +97,7 @@ func (a *Resource) Owner() *mail.Address {
 		addr, err = mail.ParseAddress(config.DefaultOwner)
 	}
 	if err != nil {
-		log.Error("DefaultOwner not properly set: ", err.Error())
+		log.Error("DefaultOwner not properly set: %s", err.Error())
 	}
 	if addr == nil {
 		log.Error("DefaultOwner not properly set.")

--- a/aws/resource.go
+++ b/aws/resource.go
@@ -95,11 +95,12 @@ func (a *Resource) Owner() *mail.Address {
 	var err error
 	if config.DefaultOwner != "" {
 		addr, err = mail.ParseAddress(config.DefaultOwner)
-	} else {
-		log.Warning("DefaultOwner is not set.")
 	}
-	if err != nil || addr == nil {
-		log.Error("Resource Owner() failed: ", err.Error())
+	if err != nil {
+		log.Error("DefaultOwner not properly set: ", err.Error())
+	}
+	if addr == nil {
+		log.Error("DefaultOwner not properly set.")
 		return nil
 	}
 	return addr

--- a/events/datadog.go
+++ b/events/datadog.go
@@ -1,19 +1,10 @@
 package events
 
-import (
-	"strconv"
-	"sync"
-
-	"github.com/PagerDuty/godspeed"
-
-	log "github.com/mozilla-services/reaper/reaperlog"
-)
+import "github.com/PagerDuty/godspeed"
 
 // DatadogConfig is the configuration for a Datadog
 type DatadogConfig struct {
 	*EventReporterConfig
-	Host string
-	Port string
 }
 
 // Datadog is a foundation for DatadogEvents and DatadogStatistics
@@ -21,7 +12,6 @@ type DatadogConfig struct {
 type Datadog struct {
 	Config    *DatadogConfig
 	_godspeed *godspeed.Godspeed
-	sync.Once
 }
 
 // NewDatadog returns a new instance of Datadog
@@ -47,31 +37,13 @@ func (e *Datadog) Cleanup() error {
 	return err
 }
 
-func (e *Datadog) getGodspeed() {
-	var gs *godspeed.Godspeed
-	var err error
-	// if config options not set, use defaults
-	if e.Config.Host == "" || e.Config.Port == "" {
-		gs, err = godspeed.NewDefault()
-	} else {
-		var port int
-		port, err = strconv.Atoi(e.Config.Port)
-		if err != nil {
-			log.Error(err.Error())
-		}
-		gs, err = godspeed.New(e.Config.Host, port, false)
-	}
-	if err != nil {
-		log.Error(err.Error())
-	}
-	e._godspeed = gs
-}
-
 func (e *Datadog) godspeed() (*godspeed.Godspeed, error) {
 	if e._godspeed == nil {
-		// Do is a method of sync.Once
-		// this will only get called once
-		e.Do(e.getGodspeed)
+		gs, err := godspeed.NewDefault()
+		if err != nil {
+			return nil, err
+		}
+		e._godspeed = gs
 	}
 	return e._godspeed, nil
 }

--- a/events/datadog.go
+++ b/events/datadog.go
@@ -54,7 +54,8 @@ func (e *Datadog) getGodspeed() {
 	if e.Config.Host == "" || e.Config.Port == "" {
 		gs, err = godspeed.NewDefault()
 	} else {
-		port, err := strconv.Atoi(e.Config.Port)
+		var port int
+		port, err = strconv.Atoi(e.Config.Port)
 		if err != nil {
 			log.Error(err.Error())
 		}

--- a/events/datadog_events.go
+++ b/events/datadog_events.go
@@ -24,13 +24,12 @@ func NewDatadogEvents(c *DatadogConfig) *DatadogEvents {
 // newEvent is a method of EventReporter
 // newEvent reports an event to Datadog
 func (e *DatadogEvents) newEvent(title string, text string, fields map[string]string, tags []string) error {
+	if log.Extras() {
+		log.Info("%s: reporting event %s, tags: %v", e.Config.Name, title, tags)
+	}
 	if e.Config.DryRun {
-		if log.Extras() {
-			log.Info("DryRun: Not reporting %s", title)
-		}
 		return nil
 	}
-
 	g, err := e.godspeed()
 	if err != nil {
 		return err
@@ -50,6 +49,12 @@ func (e *DatadogEvents) newReapableEvent(r Reapable, tags []string) error {
 		if err != nil {
 			return err
 		}
+		if log.Extras() {
+			log.Info("%s: reporting reapable event for %s, tags: %v", e.Config.Name, r.ReapableDescriptionTiny(), tags)
+		}
+		if e.Config.DryRun {
+			return nil
+		}
 		err = e.newEvent("Reapable resource discovered", text.String(), nil, tags)
 		if err != nil {
 			return fmt.Errorf("Error reporting Reapable event for %s: %s", r.ReapableDescriptionTiny(), err.Error())
@@ -62,6 +67,12 @@ func (e *DatadogEvents) newReapableEvent(r Reapable, tags []string) error {
 func (e *DatadogEvents) newBatchReapableEvent(rs []Reapable, tags []string) error {
 	errorStrings := []string{}
 	buffer := new(bytes.Buffer)
+	if log.Extras() {
+		log.Info("%s: reporting %d reapables, tags: %v", e.Config.Name, len(rs), tags)
+	}
+	if e.Config.DryRun {
+		return nil
+	}
 	for _, r := range rs {
 		if !e.Config.shouldTriggerFor(r) {
 			continue

--- a/events/datadog_statistics.go
+++ b/events/datadog_statistics.go
@@ -17,14 +17,11 @@ func NewDatadogStatistics(c *DatadogConfig) *DatadogStatistics {
 // newStatistic is a method of EventReporter
 // newStatistic reports a gauge to Datadog
 func (e *DatadogStatistics) newStatistic(name string, value float64, tags []string) error {
-	if e.Config.DryRun {
-		if log.Extras() {
-			log.Info("DryRun: Not reporting %s", name)
-		}
-		return nil
-	}
 	if log.Extras() {
-		log.Info("DatadogStatistics: reporting %s: %f, tags: %v", name, value, tags)
+		log.Info("%s: reporting %s: %f, tags: %v", e.Config.Name, name, value, tags)
+	}
+	if e.Config.DryRun {
+		return nil
 	}
 	g, err := e.godspeed()
 	if err != nil {
@@ -37,17 +34,12 @@ func (e *DatadogStatistics) newStatistic(name string, value float64, tags []stri
 // newCountStatistic is a method of EventReporter
 // newCountStatistic reports an Incr to Datadog
 func (e *DatadogStatistics) newCountStatistic(name string, tags []string) error {
+	if log.Extras() {
+		log.Info("%s: reporting %s, tags: %v", e.Config.Name, name, tags)
+	}
 	if e.Config.DryRun {
-		if log.Extras() {
-			log.Info("DryRun: Not reporting %s", name)
-		}
 		return nil
 	}
-
-	if log.Extras() {
-		log.Info("DatadogStatistics: reporting %s, tags: %v", name, tags)
-	}
-
 	g, err := e.godspeed()
 	if err != nil {
 		return err

--- a/events/events.go
+++ b/events/events.go
@@ -38,6 +38,9 @@ func Cleanup() {
 func NewEvent(title string, text string, fields map[string]string, tags []string) error {
 	errorStrings := []string{}
 	for _, er := range *eventReporters {
+		if er.GetConfig().DryRun {
+			log.Info("DryRun: %s for event %s", er.GetConfig().Name, title)
+		}
 		err := er.newEvent(title, text, fields, tags)
 		if err != nil {
 			errorStrings = append(errorStrings, err.Error())
@@ -52,6 +55,9 @@ func NewEvent(title string, text string, fields map[string]string, tags []string
 func NewStatistic(name string, value float64, tags []string) error {
 	errorStrings := []string{}
 	for _, er := range *eventReporters {
+		if er.GetConfig().DryRun {
+			log.Info("DryRun: %s for statistic %s", er.GetConfig().Name, name)
+		}
 		err := er.newStatistic(name, value, tags)
 		if err != nil {
 			errorStrings = append(errorStrings, err.Error())
@@ -66,6 +72,9 @@ func NewStatistic(name string, value float64, tags []string) error {
 func NewCountStatistic(name string, tags []string) error {
 	errorStrings := []string{}
 	for _, er := range *eventReporters {
+		if er.GetConfig().DryRun {
+			log.Info("DryRun: %s for count statistic %s", er.GetConfig().Name, name)
+		}
 		err := er.newCountStatistic(name, tags)
 		if err != nil {
 			errorStrings = append(errorStrings, err.Error())
@@ -80,6 +89,9 @@ func NewCountStatistic(name string, tags []string) error {
 func NewReapableEvent(r Reapable, tags []string) error {
 	errorStrings := []string{}
 	for _, er := range *eventReporters {
+		if er.GetConfig().DryRun {
+			log.Info("DryRun: %s for %s", er.GetConfig().Name, r.ReapableDescriptionTiny())
+		}
 		err := er.newReapableEvent(r, tags)
 		if err != nil {
 			errorStrings = append(errorStrings, err.Error())
@@ -94,6 +106,9 @@ func NewReapableEvent(r Reapable, tags []string) error {
 func NewBatchReapableEvent(rs []Reapable, tags []string) error {
 	errorStrings := []string{}
 	for _, er := range *eventReporters {
+		if er.GetConfig().DryRun {
+			log.Info("DryRun: %s for %d reapables", er.GetConfig().Name, len(rs))
+		}
 		err := er.newBatchReapableEvent(rs, tags)
 		if err != nil {
 			errorStrings = append(errorStrings, err.Error())
@@ -151,9 +166,6 @@ func (e *EventReporterConfig) parseTriggers() (triggers []state.StateEnum) {
 }
 
 func (e *EventReporterConfig) shouldTriggerFor(r Reapable) bool {
-	if e.DryRun {
-		log.Info("DryRun: %s for %s", e.Name, r.ReapableDescriptionTiny())
-	}
 	triggering := false
 	// if the reapable's state is set to trigger this EventReporter
 	for _, trigger := range e.parseTriggers() {

--- a/events/events.go
+++ b/events/events.go
@@ -111,9 +111,6 @@ func NewBatchReapableEvent(rs []Reapable, tags []string) error {
 	}
 	errorStrings := []string{}
 	for _, er := range *eventReporters {
-		if er.GetConfig().DryRun {
-			log.Info("DryRun for %d reapables", er.GetConfig().Name, len(rs))
-		}
 		err := er.newBatchReapableEvent(rs, tags)
 		if err != nil {
 			errorStrings = append(errorStrings, err.Error())

--- a/events/events.go
+++ b/events/events.go
@@ -12,6 +12,7 @@ import (
 )
 
 var eventReporters *[]EventReporter
+var dryrun bool
 
 func SetEvents(e *[]EventReporter) {
 	eventReporters = e
@@ -19,6 +20,7 @@ func SetEvents(e *[]EventReporter) {
 
 func SetDryRun(DryRun bool) {
 	// set config values for events
+	dryrun = true
 	for _, er := range *eventReporters {
 		er.setDryRun(DryRun)
 	}
@@ -36,11 +38,11 @@ func Cleanup() {
 }
 
 func NewEvent(title string, text string, fields map[string]string, tags []string) error {
+	if dryrun {
+		log.Info("DryRun for event %s", title)
+	}
 	errorStrings := []string{}
 	for _, er := range *eventReporters {
-		if er.GetConfig().DryRun {
-			log.Info("DryRun: %s for event %s", er.GetConfig().Name, title)
-		}
 		err := er.newEvent(title, text, fields, tags)
 		if err != nil {
 			errorStrings = append(errorStrings, err.Error())
@@ -53,11 +55,11 @@ func NewEvent(title string, text string, fields map[string]string, tags []string
 }
 
 func NewStatistic(name string, value float64, tags []string) error {
+	if dryrun {
+		log.Info("DryRun for statistic %s", name)
+	}
 	errorStrings := []string{}
 	for _, er := range *eventReporters {
-		if er.GetConfig().DryRun {
-			log.Info("DryRun: %s for statistic %s", er.GetConfig().Name, name)
-		}
 		err := er.newStatistic(name, value, tags)
 		if err != nil {
 			errorStrings = append(errorStrings, err.Error())
@@ -70,11 +72,11 @@ func NewStatistic(name string, value float64, tags []string) error {
 }
 
 func NewCountStatistic(name string, tags []string) error {
+	if dryrun {
+		log.Info("DryRun for count statistic %s", name)
+	}
 	errorStrings := []string{}
 	for _, er := range *eventReporters {
-		if er.GetConfig().DryRun {
-			log.Info("DryRun: %s for count statistic %s", er.GetConfig().Name, name)
-		}
 		err := er.newCountStatistic(name, tags)
 		if err != nil {
 			errorStrings = append(errorStrings, err.Error())
@@ -87,11 +89,11 @@ func NewCountStatistic(name string, tags []string) error {
 }
 
 func NewReapableEvent(r Reapable, tags []string) error {
+	if dryrun {
+		log.Info("DryRun for ReapableEvent %s", r.ReapableDescriptionShort())
+	}
 	errorStrings := []string{}
 	for _, er := range *eventReporters {
-		if er.GetConfig().DryRun {
-			log.Info("DryRun: %s for %s", er.GetConfig().Name, r.ReapableDescriptionTiny())
-		}
 		err := er.newReapableEvent(r, tags)
 		if err != nil {
 			errorStrings = append(errorStrings, err.Error())
@@ -104,10 +106,13 @@ func NewReapableEvent(r Reapable, tags []string) error {
 }
 
 func NewBatchReapableEvent(rs []Reapable, tags []string) error {
+	if dryrun {
+		log.Info("DryRun for BatchReapableEvent for %d reapables", len(rs))
+	}
 	errorStrings := []string{}
 	for _, er := range *eventReporters {
 		if er.GetConfig().DryRun {
-			log.Info("DryRun: %s for %d reapables", er.GetConfig().Name, len(rs))
+			log.Info("DryRun for %d reapables", er.GetConfig().Name, len(rs))
 		}
 		err := er.newBatchReapableEvent(rs, tags)
 		if err != nil {

--- a/events/events.go
+++ b/events/events.go
@@ -152,10 +152,7 @@ func (e *EventReporterConfig) parseTriggers() (triggers []state.StateEnum) {
 
 func (e *EventReporterConfig) shouldTriggerFor(r Reapable) bool {
 	if e.DryRun {
-		if log.Extras() {
-			log.Info("DryRun: Not triggering %s for %s", e.Name, r.ReapableDescriptionTiny())
-		}
-		return false
+		log.Info("DryRun: %s for %s", e.Name, r.ReapableDescriptionTiny())
 	}
 	triggering := false
 	// if the reapable's state is set to trigger this EventReporter

--- a/events/mailer.go
+++ b/events/mailer.go
@@ -127,11 +127,10 @@ func (e *Mailer) newReapableEvent(r Reapable, tags []string) error {
 			return err
 		}
 		if log.Extras() {
-			log.Info("%s: sending email to %s for %s with state",
+			log.Info("%s: sending email to %s for %s",
 				e.Config.Name,
 				addr.Address,
-				r.ReapableDescriptionTiny(),
-				r.ReaperState().State.String())
+				r.ReapableDescriptionShort())
 		}
 		if e.Config.DryRun {
 			return nil

--- a/events/reaperevent.go
+++ b/events/reaperevent.go
@@ -50,7 +50,7 @@ func (e *ReaperEvent) newReapableEvent(r Reapable, tags []string) error {
 		switch e.Config.Mode {
 		case "Stop":
 			if log.Extras() {
-				log.Info("%s: Stopping ", e.Config.Name, r.ReapableDescriptionShort())
+				log.Info("%s: Stopping %s", e.Config.Name, r.ReapableDescriptionShort())
 			}
 			if e.Config.DryRun {
 				return nil
@@ -60,7 +60,7 @@ func (e *ReaperEvent) newReapableEvent(r Reapable, tags []string) error {
 			_, err = r.Stop()
 		case "Terminate":
 			if log.Extras() {
-				log.Info("%s: Terminating ", e.Config.Name, r.ReapableDescriptionShort())
+				log.Info("%s: Terminating %s", e.Config.Name, r.ReapableDescriptionShort())
 			}
 			if e.Config.DryRun {
 				return nil

--- a/events/reaperevent.go
+++ b/events/reaperevent.go
@@ -17,10 +17,7 @@ type ReaperEventConfig struct {
 // that it triggers whether or not the state was updated this run
 func (e *ReaperEventConfig) shouldTriggerFor(r Reapable) bool {
 	if e.DryRun {
-		if log.Extras() {
-			log.Info("DryRun: Not triggering %s for %s", e.Name, r.ReapableDescriptionTiny())
-		}
-		return false
+		log.Info("DryRun: %s for %s", e.Name, r.ReapableDescriptionTiny())
 	}
 	triggering := false
 	// if the reapable's state is set to trigger this EventReporter
@@ -55,15 +52,25 @@ func (e *ReaperEvent) newReapableEvent(r Reapable, tags []string) error {
 		var err error
 		switch e.Config.Mode {
 		case "Stop":
-			_, err = r.Stop()
-			log.Info("ReaperEvent: Stopping ", r.ReapableDescriptionShort())
+			if log.Extras() {
+				log.Info("%s: Stopping ", e.Config.Name, r.ReapableDescriptionShort())
+			}
+			if e.Config.DryRun {
+				return nil
+			}
 			NewEvent("Reaper: Stopping ", r.ReapableDescriptionShort(), nil, []string{})
 			NewCountStatistic("reaper.reapables.stopped", []string{r.ReapableDescriptionTiny()})
+			_, err = r.Stop()
 		case "Terminate":
-			_, err = r.Terminate()
-			log.Info("ReaperEvent: Terminating ", r.ReapableDescriptionShort())
+			if log.Extras() {
+				log.Info("%s: Terminating ", e.Config.Name, r.ReapableDescriptionShort())
+			}
+			if e.Config.DryRun {
+				return nil
+			}
 			NewEvent("Reaper: Terminating ", r.ReapableDescriptionShort(), nil, []string{})
 			NewCountStatistic("reaper.reapables.terminated", []string{r.ReapableDescriptionTiny()})
+			_, err = r.Terminate()
 		default:
 			log.Error(fmt.Sprintf("Invalid %s Mode %s", e.Config.Name, e.Config.Mode))
 		}

--- a/events/reaperevent.go
+++ b/events/reaperevent.go
@@ -16,9 +16,6 @@ type ReaperEventConfig struct {
 // this is a copy of the method from events.go EXCEPT
 // that it triggers whether or not the state was updated this run
 func (e *ReaperEventConfig) shouldTriggerFor(r Reapable) bool {
-	if e.DryRun {
-		log.Info("DryRun: %s for %s", e.Name, r.ReapableDescriptionTiny())
-	}
 	triggering := false
 	// if the reapable's state is set to trigger this EventReporter
 	for _, trigger := range e.parseTriggers() {

--- a/events/tagger.go
+++ b/events/tagger.go
@@ -30,7 +30,12 @@ func (e *Tagger) newReapableEvent(r Reapable, tags []string) error {
 	}
 
 	if e.Config.shouldTriggerFor(r) {
-		log.Info("Tagging %s with %s", r.ReapableDescriptionTiny(), r.ReaperState().State.String())
+		if log.Extras() {
+			log.Info("%s: Tagging %s with %s", e.Config.Name, r.ReapableDescriptionTiny(), r.ReaperState().State.String())
+		}
+		if e.Config.DryRun {
+			return nil
+		}
 		_, err := r.Save(r.ReaperState())
 		if err != nil {
 			return err

--- a/main.go
+++ b/main.go
@@ -108,7 +108,7 @@ func main() {
 	reaperevents.SetEvents(&eventReporters)
 
 	if config.DryRun {
-		log.Info("Dry run mode enabled, no events will be triggered. Enable Extras in Notifications for per-event DryRun notifications.")
+		log.Info("Dry run mode enabled, no events will be triggered.")
 		reaperevents.SetDryRun(config.DryRun)
 	}
 


### PR DESCRIPTION
Simplify DefaultOwner - now just an email address

add lots of logging for EventReporters when they trigger (with logging extras enabled), make them more sensitive to DryRuns, and generally improve DryRun logging

@oremj r?
